### PR TITLE
Fixed small typo in filename that gave error

### DIFF
--- a/blend.lua
+++ b/blend.lua
@@ -2,7 +2,7 @@ require 'image'
 
 for i=1,32 do
     src=image.load(string.format('examples/input_%04d.png',i))
-    tgt=image.load(string.format('examples/demo_real_%04d.pngTOfake_%04d.png.jpg',i,i))
+    tgt=image.load(string.format('examples/demo_input_%04d.pngTOfake_%04d.png.jpg',i,i))
     mask=image.load('mask.png')
     mask=mask[{{1,3},{},{}}]
 	res=torch.cmul(src,mask)+torch.cmul(tgt,1-mask)


### PR DESCRIPTION
The files were saved like 'examples/demo_input_%04d.pngTOfake_%04d.png.jpg' for me so I suspect it's a small typo.