### PR TITLE
Switch content network to evaluation mode at test stage.

### DIFF
--- a/run_content_network.lua
+++ b/run_content_network.lua
@@ -24,6 +24,7 @@ local function loadImage(path,size)
 end
 
 modelG=util.load(opt.model_file,opt.gpu)
+modelG:evaluate()
 
 local real=torch.Tensor(32,3,512,512)
 local real_ctx = torch.Tensor(32,3,128,128)


### PR DESCRIPTION
Using evaluation mode at test stage ensures that result for particular image isn't affected by other images in the batch.
It also improves visual quality of some results.

| Before | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/6138700/40687375-1a2a3da6-63a3-11e8-8c6c-bd0ff84a1baa.png) | ![image](https://user-images.githubusercontent.com/6138700/40687389-215f57dc-63a3-11e8-9697-2894814a9d23.png) |

